### PR TITLE
Remove dependency on "idleberg.haskell-nsis"

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,9 +66,6 @@
     "npm-run-all": "^4.1.5",
     "typescript": "^4.6.2"
   },
-  "extensionDependencies": [
-    "idleberg.haskell-nsis"
-  ],
   "icon": "images/logo.png",
   "galleryBanner": {
     "color": "#9e90aa",


### PR DESCRIPTION
Removing this extension dependency should let us uninstall the Haskell extension.

Right now we just get an error:

`Cannot uninstall 'Haskell NSIS' extension. 'NSIS' extension depends on this.`
