### PR TITLE
Pass calling process env when launching makensis

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -280,6 +280,8 @@ export async function getSpawnEnv(): Promise<SpawnOptions> {
 
 	return {
 		env: {
+			// start with calling process env (this provides e.g. %PATH% on Windows)
+			...process.env,
 			NSISDIR: integrated.env[mappedPlatform].NSISDIR || process.env.NSISDIR || undefined,
 			NSISCONFDIR: integrated.env[mappedPlatform].NSISCONFDIR || process.env.NSISCONFDIR || undefined,
 			LANGUAGE: !isWindows() && !process.env.LANGUAGE ? 'en_US.UTF-8' : undefined,


### PR DESCRIPTION
Build started failing after I added a `!system` command in the script. On Windows 11 23H2 22631.4460 with MakeNSIS v3.10.

I looked into the source and noticed that the environment variables passed to the `MakeNSIS` do not contain `PATH` which could be a cause of the problem. Adding only `PATH` did not help, maybe `ComSpec` is needed, I did not investigate further.

I believe passing the whole env. from VS Code extension context to `MakeNSIS` presents no security risk, since it's the same env. that `MakeNSIS` gets if the user opens it from the Start Menu.

This fixes #40.